### PR TITLE
dropped rethrown errors

### DIFF
--- a/lib/crowdrz.js
+++ b/lib/crowdrz.js
@@ -75,9 +75,14 @@ class Crowdrz {
     try {
       data = await servicesList[this.provider].getData({apiToken: this.apiToken, ...this.request})
     } catch (error) {
-      throw new Error(error)
+      if (this.debug) {
+        console.log(error.message, '\n')
+      }
+      throw error
+    } finally {
+      this._resetQuery()
     }
-    this._resetQuery()
+
     return data
   }
 

--- a/lib/services/facebook/index.js
+++ b/lib/services/facebook/index.js
@@ -25,12 +25,8 @@ const getData = async (request, _accumulator = [], totalLimit = null) => {
   }
 
   let apiRes = null
-  try {
-    // Call facebook SDK
-    apiRes = await FB.api(request.endpoint, request.method, request.params)
-  } catch (error) {
-    throw new Error(error)
-  }
+  // Call facebook SDK
+  apiRes = await FB.api(request.endpoint, request.method, request.params)
 
   // Recursive block
   if (totalLimit && apiRes.paging && apiRes.paging.cursors) {


### PR DESCRIPTION
Errors should not be catched an rethrown as is.
When rethrowing an error we loose some error information like stacktrace and in this case, we were overriding message with the error stringified.
